### PR TITLE
hotfix(telegram): switch skill scanning on Support gems only.

### DIFF
--- a/modules/spring-telegram-webhook/src/main/java/io/starter/repo/ProcessedSkillsRepository.java
+++ b/modules/spring-telegram-webhook/src/main/java/io/starter/repo/ProcessedSkillsRepository.java
@@ -7,6 +7,8 @@ import io.starter.entity.ProcessedSkillEntity;
 
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ProcessedSkillsRepository extends JpaRepository<ProcessedSkillEntity, Long> {
 
@@ -17,4 +19,17 @@ public interface ProcessedSkillsRepository extends JpaRepository<ProcessedSkillE
   List<ProcessedSkillEntity> findAllByLeagueAndChaosEquivalentProfitGreaterThan(LeagueEntity league,
                                                                                 double chaosEquivalentProfit,
                                                                                 Sort sort);
+
+  @Query("""
+        SELECT p FROM ProcessedSkillEntity p
+        WHERE p.league = :league
+          AND LOWER(p.skill.name) LIKE LOWER(CONCAT('%', :namePart, '%'))
+          AND p.chaosEquivalentProfit > :chaosProfit
+      """)
+  List<ProcessedSkillEntity> searchByNameContaining(
+      @Param("league") LeagueEntity league,
+      @Param("namePart") String namePart,
+      @Param("chaosProfit") double chaosEquivalentProfit,
+      Sort sort
+  );
 }

--- a/modules/spring-telegram-webhook/src/main/java/io/starter/service/DataAccessService.java
+++ b/modules/spring-telegram-webhook/src/main/java/io/starter/service/DataAccessService.java
@@ -23,8 +23,12 @@ public class DataAccessService {
 
   public List<Skill> findAllSkills(LeagueEntity league) {
     final String column = "chaosEquivalentProfit";
-    List<ProcessedSkillEntity> all = processedSkillsRepository
-        .findAllByLeagueAndChaosEquivalentProfitGreaterThan(league, 0.0, Sort.by(Sort.Direction.DESC, column));
+    List<ProcessedSkillEntity> all = processedSkillsRepository.searchByNameContaining(
+        league,
+        "Support",
+        0.0,
+        Sort.by(Sort.Direction.DESC, column)
+    );
     return all.stream().map(entity -> {
       Skill skill = new Skill();
       skill.setName(entity.getSkill().getName());


### PR DESCRIPTION
- game changed vendor recipe (only support gems and awakened gems)

## Checklist

- [ ] Checkstyle and unit tests are passed locally with my changes by running <br>`gradlew check`
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
