### PR TITLE
ci(actions): use quokkify compose action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
         run: tools/scripts/mock/run_mock_server.sh
         shell: bash
       - name: 🟢 Start Application
-        uses: ylazakovich/compose-health-check-action@a13ee83cb11ca820617b29fbb58551f7eaf39943
+        uses: quokkify/compose-health-check-action@a13ee83cb11ca820617b29fbb58551f7eaf39943
         with:
           docker-command: |
             docker compose \


### PR DESCRIPTION
## Summary

- update the pinned Compose health action owner after the repository transfer
- preserve the exact immutable action commit `a13ee83cb11ca820617b29fbb58551f7eaf39943`
- make no workflow behavior or Docker configuration changes

## Verification

- confirmed the pinned commit exists in `quokkify/compose-health-check-action`
- `actionlint .github/workflows/test.yml`
- `git diff --check`
- confirmed no stale `ylazakovich/compose-health-check-action` reference remains in `.github`
- Docker was not run locally; GitHub CI remains the runtime gate


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated workflow’s health-check action reference while preserving the existing pinned version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->